### PR TITLE
Add Makefile for sqllite DB

### DIFF
--- a/src/data/.gitignore
+++ b/src/data/.gitignore
@@ -1,0 +1,1 @@
+hotspot.db

--- a/src/data/Makefile
+++ b/src/data/Makefile
@@ -1,0 +1,35 @@
+SHELL := bash
+.ONESHELL:
+.DELETE_ON_ERROR:
+
+DB      := hotspot.db
+SCHEMA  := create_tables.txt
+CSVS    := default_risk.csv model_risk.csv postcode_risk.csv
+
+# This is a hack (or really clever?) but uses the file name of the csvs as the table name 
+define IMPORT_LINE
+.import --csv --skip 1 '$(1)' $(basename $(notdir $(1)))
+endef
+IMPORTS := $(foreach f,$(CSVS),$(call IMPORT_LINE,$(f)))
+
+.PHONY: all rebuild clean
+all: $(DB)
+
+$(DB): $(SCHEMA) $(CSVS)
+	@set -euo pipefail; \
+	tmp="$(DB).tmp"; \
+	rm -f "$$tmp"; \
+	{ \
+		echo ".read $(SCHEMA)"; \
+		echo ".mode csv"; \
+		echo ".separator ,"; \
+		$(foreach f,$(CSVS),echo ".import --csv --skip 1 '$(f)' $(basename $(notdir $(f)))";) \
+	} | sqlite3 -batch "$$tmp"; \
+	mv "$$tmp" "$(DB)"; \
+	echo Done.
+
+rebuild: clean all
+
+clean:
+	rm -f "$(DB)"
+

--- a/src/data/README.md
+++ b/src/data/README.md
@@ -1,0 +1,83 @@
+# Hotspot SQLite Database
+
+## Developer Documentation
+
+### Requirements
+
+You'll need `sqlite3` installed.
+
+On macOS you can install it with Homebrew (if not already installed)
+
+```
+brew install sqlite
+```
+
+On Linux, use your system package manager, e.g.:
+
+```
+sudo apt-get install sqlite3
+```
+
+### Building the Database
+
+The Makefile will generate a SQLite database (`hotspot.db`) from a schema file and CSV datasets.  
+
+Run:
+```
+make
+```
+
+This will:
+1. Create a temporary SQLite database.
+2. Apply the schema from `create_tables.txt`.
+3. Import the CSV files into tables automatically (table name = CSV file name without extension).
+4. Rename the temporary database to `hotspot.db`.
+
+### Rebuilding the Database
+
+If you need to rebuild from scratch:
+
+```
+make rebuild
+```
+
+This will remove the old database and regenerate it.
+
+### Cleaning Up
+
+To remove the generated database:
+
+```
+make clean
+```
+
+### CSV Imports
+
+The following CSVs are imported:
+- `default_risk.csv` → `default_risk` table
+- `model_risk.csv` → `model_risk` table
+- `postcode_risk.csv` → `postcode_risk` table
+
+> **Note**: The Makefile automatically infers the table name from the CSV filename.
+
+### Verifying the Database
+
+After building, you can explore the database interactively:
+
+```
+sqlite3 hotspot.db
+```
+
+For example, to list tables:
+
+```
+.tables
+```
+
+And to inspect a schema:
+
+```
+.schema <table_name>
+```
+
+


### PR DESCRIPTION
This adds in a Makefile and a short README on how to generate the sqllite db that will back the API

https://trello.com/c/R9Zjibkw/57-211-generate-sqlite-from-schema-and-csv