### PR TITLE
Add additional API endpoints that match the DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 .pytest_cache/
 .coverage
 dist/
+.DS_Store

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
 from database import Database
-from routes import health, search
+from routes import health, search, bikes, lgas, risk, stats
 
 
 parser = argparse.ArgumentParser(description="Hotspot API Server")
@@ -46,6 +46,10 @@ app.state.db = db
 
 app.include_router(health.router, prefix="/api")
 app.include_router(search.router, prefix="/api")
+app.include_router(lgas.router, prefix="/api")
+app.include_router(risk.router, prefix="/api")
+app.include_router(stats.router, prefix="/api")
+app.include_router(bikes.router, prefix="/api")
 
 if static_path.exists():
     @app.get("/")

--- a/src/api/routes/bikes.py
+++ b/src/api/routes/bikes.py
@@ -1,0 +1,42 @@
+from fastapi import APIRouter, Query, Request
+from fastapi.responses import PlainTextResponse
+
+router = APIRouter()
+
+@router.get("/v1/models")
+def list_models(
+    request: Request,
+    brand: str | None = None,
+    model: str | None = None,
+    min_total: int = Query(0, ge=0),
+    sort: str = Query("risk_desc", description="risk_desc|risk_asc|total_desc|total_asc|brand|model"),
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+):
+    db = request.app.state.db
+    clauses, params = ["total >= :min_total"], {"min_total": min_total}
+    if brand: clauses.append("brand LIKE '%' || :brand || '%'"); params["brand"]=brand.lower()
+    if model: clauses.append("model LIKE '%' || :model || '%'"); params["model"]=model.lower()
+    where_sql = "WHERE " + " AND ".join(clauses)
+    sort_sql = {"risk_desc":"model_risk DESC","risk_asc":"model_risk ASC","total_desc":"total DESC","total_asc":"total ASC","brand":"brand ASC","model":"model ASC"}.get(sort,"model_risk DESC")
+    return db.fetch_all(f"""
+        SELECT brand, model, total, percentage, model_risk
+        FROM model_risk
+        {where_sql}
+        ORDER BY {sort_sql}
+        LIMIT :limit OFFSET :offset
+    """, {**params, "limit": limit, "offset": offset})
+
+@router.get("/v1/models/{brand}/{model}")
+def model_detail(request: Request, brand: str, model: str):
+    db = request.app.state.db
+    row = db.fetch_all("""
+        SELECT brand, model, total, percentage, model_risk
+        FROM model_risk
+        WHERE brand = :b AND model = :m
+        LIMIT 1
+    """, {"b": brand.lower(), "m": model.lower()})
+    if not row:
+        raise HTTPException(status_code=404, detail="Model not found")
+    return row[0]
+

--- a/src/api/routes/lgas.py
+++ b/src/api/routes/lgas.py
@@ -1,0 +1,38 @@
+from fastapi import APIRouter, Query, Request
+from fastapi.responses import PlainTextResponse
+
+router = APIRouter()
+
+@router.get("/v1/lgas")
+def lga_rollups(request: Request, q: str | None = None, sort: str = Query("avg_desc")):
+    db = request.app.state.db
+    where = "WHERE local_government_area LIKE '%' || :q || '%'" if q else ""
+    params = {"q": q} if q else {}
+    sort_sql = {"avg_desc":"avg_risk DESC","avg_asc":"avg_risk ASC","count_desc":"postcode_count DESC","count_asc":"postcode_count ASC","lga":"lga ASC"}.get(sort,"avg_desc")
+    return db.fetch_all(f"""
+        SELECT local_government_area AS lga,
+               COUNT(*) AS postcode_count,
+               ROUND(AVG(postcode_risk), 6) AS avg_risk,
+               MIN(postcode_risk) AS min_risk,
+               MAX(postcode_risk) AS max_risk
+        FROM postcode_risk
+        {where}
+        GROUP BY local_government_area
+        ORDER BY {sort_sql}
+    """, params)
+
+@router.get("/v1/lgas/{lga}/postcodes")
+def lga_postcodes(request: Request, lga: str, order: str = Query("desc", description="desc|asc")):
+    db = request.app.state.db
+    order_sql = "DESC" if order == "desc" else "ASC"
+    rows = db.fetch_all(f"""
+        SELECT postcode, locality AS suburb, long, lat,
+               postcode_risk AS risk_score
+        FROM postcode_risk
+        WHERE local_government_area = :lga
+        ORDER BY postcode_risk {order_sql}, postcode ASC
+    """, {"lga": lga})
+    if not rows:
+        raise HTTPException(status_code=404, detail="LGA not found or empty")
+    return rows
+

--- a/src/api/routes/risk.py
+++ b/src/api/routes/risk.py
@@ -1,0 +1,18 @@
+from fastapi import APIRouter, Query, Request
+from fastapi.responses import PlainTextResponse
+
+router = APIRouter()
+
+@router.get("/v1/risk/compare")
+def risk_compare(request: Request, postcode: str = Query(...)):
+    db = request.app.state.db
+    base = db.fetch_all("""
+        SELECT postcode, locality AS suburb, local_government_area AS lga,
+               motorcycle_theft_rate, postcode_risk AS risk_score
+        FROM postcode_risk WHERE postcode = :pc LIMIT 1
+    """, {"pc": postcode})
+    if not base:
+        raise HTTPException(status_code=404, detail="Postcode not found")
+    defaults = db.fetch_all("SELECT * FROM default_risk LIMIT 1")
+    return {"base": base[0], "defaults": (defaults[0] if defaults else None)}
+

--- a/src/api/routes/search.py
+++ b/src/api/routes/search.py
@@ -3,7 +3,6 @@ from fastapi.responses import PlainTextResponse
 
 router = APIRouter()
 
-
 @router.get("/v1/search")
 def search(request: Request, q: str = Query(..., description="Search query for suburb or postcode")):
     db = request.app.state.db

--- a/src/api/routes/stats.py
+++ b/src/api/routes/stats.py
@@ -1,0 +1,38 @@
+from fastapi import APIRouter, Query, Request
+from fastapi.responses import PlainTextResponse
+
+router = APIRouter()
+
+@router.get("/v1/risk/top")
+def risk_top(request: Request, scope: str = "postcode", order: str = "desc", limit: int = Query(20, ge=1, le=200)):
+    db = request.app.state.db
+    if scope == "postcode":
+        return db.fetch_all(f"""
+            SELECT postcode, locality AS suburb, local_government_area AS lga,
+                   postcode_risk AS risk_score
+            FROM postcode_risk
+            ORDER BY risk_score {"DESC" if order=="desc" else "ASC"}
+            LIMIT :limit
+        """, {"limit": limit})
+    if scope == "lga":
+        return db.fetch_all(f"""
+            SELECT local_government_area AS lga,
+                   ROUND(AVG(postcode_risk),6) AS avg_risk,
+                   COUNT(*) AS postcode_count
+            FROM postcode_risk
+            GROUP BY local_government_area
+            ORDER BY avg_risk {"DESC" if order=="desc" else "ASC"}
+            LIMIT :limit
+        """, {"limit": limit})
+    raise HTTPException(status_code=400, detail="scope must be postcode or lga")
+
+@router.get("/v1/stats/summary")
+def stats_summary(request: Request):
+    db = request.app.state.db
+    return db.fetch_all("""
+        SELECT
+          (SELECT COUNT(*) FROM postcode_risk) AS total_postcodes,
+          (SELECT COUNT(DISTINCT local_government_area) FROM postcode_risk) AS total_lgas,
+          (SELECT ROUND(AVG(postcode_risk),6) FROM postcode_risk) AS avg_postcode_risk,
+          (SELECT COUNT(*) FROM model_risk) AS total_models
+    """)[0]


### PR DESCRIPTION
This PR extends the Hotspot API with new endpoints for theft models and bike model/LGA rollups, plus minor housekeeping



routes/bikes.py: /v1/models, /v1/models/{brand}/{model} for bike model risk
routes/lgas.py: /v1/lgas, /v1/lgas/{lga}/postcodes for LGA rollups
routes/risk.py: /v1/risk/compare to compare postcode vs. defaults
routes/stats.py: /v1/risk/top, /v1/stats/summary for leaderboards and KPIs
