### PR TITLE
Add API to add parking suggestions

### DIFF
--- a/src/api/database.py
+++ b/src/api/database.py
@@ -17,3 +17,13 @@ class Database:
             return [dict(row) for row in rows]
         finally:
             conn.close()
+
+    def execute(self, query: str, params: Dict[str, Any] = None):
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+        try:
+            cursor.execute(query, params or {})
+            conn.commit()
+            return cursor.lastrowid
+        finally:
+            conn.close()

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
 from database import Database
-from routes import health, search, bikes, lgas, risk, stats, addresses
+from routes import health, search, bikes, lgas, risk, stats, addresses, parking
 
 
 parser = argparse.ArgumentParser(description="Hotspot API Server")
@@ -51,6 +51,7 @@ app.include_router(risk.router, prefix="/api")
 app.include_router(stats.router, prefix="/api")
 app.include_router(bikes.router, prefix="/api")
 app.include_router(addresses.router, prefix="/api")
+app.include_router(parking.router, prefix="/api")
 
 if static_path.exists():
     @app.get("/")

--- a/src/api/routes/parking.py
+++ b/src/api/routes/parking.py
@@ -1,0 +1,104 @@
+from fastapi import APIRouter, Request, HTTPException
+from pydantic import BaseModel, Field
+from typing import Optional, List
+from datetime import datetime
+
+router = APIRouter()
+
+class ParkingSubmission(BaseModel):
+    address: str = Field(..., description="Street address")
+    suburb: str = Field(..., description="Suburb name")
+    postcode: str = Field(..., description="Postcode")
+    type: str = Field(..., description="Parking type", pattern="^(on-street|off-street|secure)$")
+    lighting: Optional[int] = Field(None, ge=1, le=4, description="Lighting quality: 1=poor, 2=fair, 3=good, 4=excellent")
+    cctv: Optional[bool] = Field(None, description="CCTV availability: true, false, or null for unknown")
+    facilities: Optional[List[int]] = Field(default=[], description="List of facility IDs")
+
+class ParkingResponse(BaseModel):
+    parking_id: int
+    message: str
+
+@router.post("/v1/parking", response_model=ParkingResponse)
+def submit_parking(
+    request: Request,
+    submission: ParkingSubmission
+):
+    db = request.app.state.db
+
+    try:
+        # To prevent abuse we only allow addresses that we know about (no custom ones)
+        address_check = db.fetch_all("""
+            SELECT address, suburb, postcode
+            FROM victorian_addresses
+            WHERE UPPER(address) = UPPER(:address)
+              AND UPPER(suburb) = UPPER(:suburb)
+              AND postcode = :postcode
+        """, {
+            "address": submission.address,
+            "suburb": submission.suburb,
+            "postcode": submission.postcode
+        })
+
+        if not address_check:
+            raise HTTPException(
+                status_code=400,
+                detail="Invalid address"
+            )
+
+        verified_address = address_check[0]
+
+        parking_id = db.execute("""
+            INSERT INTO user_contribution (address, suburb, postcode, type, lighting, cctv)
+            VALUES (:address, :suburb, :postcode, :type, :lighting, :cctv)
+        """, {
+            "address": verified_address["address"],
+            "suburb": verified_address["suburb"],
+            "postcode": verified_address["postcode"],
+            "type": submission.type,
+            "lighting": submission.lighting,
+            "cctv": submission.cctv
+        })
+
+        if submission.facilities:
+            for facility_id in submission.facilities:
+                db.execute("""
+                    INSERT INTO user_contribution_facilities (parking_id, facility_id)
+                    VALUES (:parking_id, :facility_id)
+                """, {
+                    "parking_id": parking_id,
+                    "facility_id": facility_id
+                })
+
+        return ParkingResponse(
+            parking_id=parking_id,
+            message="Parking suggestion submitted successfully"
+        )
+
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to submit parking suggestion: {str(e)}")
+
+@router.get("/v1/parking/{postcode}")
+def get_parking_by_postcode(
+    request: Request,
+    postcode: str
+):
+    db = request.app.state.db
+
+    parking_list = db.fetch_all("""
+        SELECT parking_id, address, suburb, postcode, type, lighting, cctv, created_at
+        FROM user_contribution
+        WHERE postcode = :postcode
+        ORDER BY created_at DESC
+        LIMIT 20
+    """, {"postcode": postcode})
+
+    for parking in parking_list:
+        facilities = db.fetch_all("""
+            SELECT f.facility_id, f.facility_name
+            FROM user_contribution_facilities ucf
+            JOIN facilities f ON ucf.facility_id = f.facility_id
+            WHERE ucf.parking_id = :parking_id
+        """, {"parking_id": parking["parking_id"]})
+        parking["facilities"] = facilities
+
+    return parking_list

--- a/src/data/create_tables.txt
+++ b/src/data/create_tables.txt
@@ -31,14 +31,14 @@ CREATE TABLE user_input (
 );
 
 CREATE TABLE user_contribution (
-  parking_id INTEGER PRIMARY KEY AUTOINCREMENT, 
-  postcode TEXT NOT NULL, 
-  suburb TEXT,
+  parking_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  address TEXT NOT NULL,
+  suburb TEXT NOT NULL,
+  postcode TEXT NOT NULL,
   type TEXT CHECK(type IN ('on-street', 'off-street', 'secure')) NOT NULL,
-  long DOUBLE PRECISION,
-  lat DOUBLE PRECISION,
-  lighting BOOLEAN DEFAULT 0, 
-  cctv BOOLEAN DEFAULT 0, 
+  /* The integers map to the UI, poor (1), fair (2), good (3), excellent (4) */
+  lighting INTEGER CHECK(lighting IN (1, 2, 3, 4)),
+  cctv BOOLEAN,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -65,7 +65,7 @@ INSERT INTO facilities (facility_name) VALUES
 
 CREATE TABLE votes (
   vote_id INTEGER PRIMARY KEY AUTOINCREMENT, 
-  parking_id INTEGER NOT NULL, 
+  parking_id INTEGER NOT NULL,  
   vote_type TEXT CHECK(vote_type IN ('upvote', 'downvote')) NOT NULL, 
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, 
   FOREIGN KEY (parking_id) REFERENCES user_contributions(parking_id) ON DELETE CASCADE

--- a/src/web/src/components/ParkingLocationForm.vue
+++ b/src/web/src/components/ParkingLocationForm.vue
@@ -88,8 +88,6 @@ import { ref, watch } from 'vue';
 interface AddressSuggestion {
   display: string;
   value: string;
-  lat?: number;
-  lng?: number;
 }
 
 const props = defineProps<{


### PR DESCRIPTION
Note that this right only only persists to sqllite which is wiped on every deployment, eventually this will be relegated to just development only (and for testing) and we'll persist to DynamoDB in AWS.

This adds `/v1/parking/` which takes an address and some metadata (lighting, cctv, etc.). For safety we don't accept any "custom" addresses, only ones that we know about

