### PR TITLE
8.3.3 Add API to show nearest suburbs

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -9,7 +9,7 @@ from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
 from db_interface import get_database
-from routes import health, search, bikes, lgas, risk, stats, addresses, parking, contact
+from routes import health, search, bikes, lgas, risk, stats, addresses, parking, contact, postcodes
 
 
 logging.basicConfig(
@@ -72,6 +72,7 @@ app.include_router(bikes.router, prefix="/api")
 app.include_router(addresses.router, prefix="/api")
 app.include_router(parking.router, prefix="/api")
 app.include_router(contact.router, prefix="/api")
+app.include_router(postcodes.router, prefix="/api")
 
 if static_path.exists():
     @app.get("/")

--- a/src/api/pyproject.toml
+++ b/src/api/pyproject.toml
@@ -8,4 +8,6 @@ dependencies = [
     "fastapi[standard]>=0.116.1",
     "uvicorn[standard]>=0.35.0",
     "boto3>=1.35.0",
+    "requests>=2.31.0",
+    "PyGithub>=2.1.0",
 ]

--- a/src/api/routes/postcodes.py
+++ b/src/api/routes/postcodes.py
@@ -1,0 +1,30 @@
+from fastapi import APIRouter, Request, HTTPException
+from typing import List, Dict, Any
+
+router = APIRouter()
+
+@router.get("/v1/postcode/{postcode}/nearest")
+def get_nearest_postcodes(request: Request, postcode: str) -> List[Dict[str, Any]]:
+    db = request.app.state.db
+
+    target_exists = db.fetch_all("""
+        SELECT postcode FROM postcode_risk WHERE postcode = :postcode LIMIT 1
+    """, {"postcode": postcode})
+
+    if not target_exists:
+        raise HTTPException(status_code=404, detail=f"Postcode {postcode} not found")
+
+    nearest_postcodes = db.fetch_all("""
+        SELECT
+            pd.secondary_postcode as postcode,
+            pr.locality as suburb,
+            pr.local_government_area as lga,
+            pd.distance_meters as distance_in_meters
+        FROM postcode_distances pd
+        JOIN postcode_risk pr ON pd.secondary_postcode = pr.postcode
+        WHERE pd.primary_postcode = :postcode
+        ORDER BY pd.distance_meters ASC
+        LIMIT 20
+    """, {"postcode": postcode})
+
+    return nearest_postcodes

--- a/src/api/uv.lock
+++ b/src/api/uv.lock
@@ -320,6 +320,7 @@ dependencies = [
     { name = "boto3" },
     { name = "fastapi", extra = ["standard"] },
     { name = "pygithub" },
+    { name = "requests" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -327,7 +328,8 @@ dependencies = [
 requires-dist = [
     { name = "boto3", specifier = ">=1.35.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.116.1" },
-    { name = "pygithub", specifier = ">=2.8.1" },
+    { name = "pygithub", specifier = ">=2.1.0" },
+    { name = "requests", specifier = ">=2.31.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.35.0" },
 ]
 

--- a/src/data/Makefile
+++ b/src/data/Makefile
@@ -4,7 +4,7 @@ SHELL := bash
 
 DB      := hotspot.db
 SCHEMA  := create_tables.txt
-CSVS    := default_risk.csv model_risk.csv postcode_risk.csv victorian_addresses.csv
+CSVS    := default_risk.csv model_risk.csv postcode_risk.csv victorian_addresses.csv postcode_distances.csv
 
 # This is a hack (or really clever?) but uses the file name of the csvs as the table name 
 define IMPORT_LINE

--- a/src/data/create_tables.txt
+++ b/src/data/create_tables.txt
@@ -69,6 +69,12 @@ CREATE TABLE victorian_addresses (
     postcode TEXT NOT NULL
 );
 
+CREATE TABLE postcode_distances (
+    primary_postcode TEXT NOT NULL,
+    secondary_postcode TEXT NOT NULL,
+    distance_meters REAL NOT NULL
+);
+
 CREATE TABLE carpark_counts (
     postcode TEXT NOT NULL,
     carpark_count INTEGER NOT NULL


### PR DESCRIPTION
for instance `/api/v1/postcode/3006/nearest` will show (up to 20) of the nearest suburbs:

in a format like:

```
[
  {
    "postcode": "3205",
    "suburb": "SOUTH MELBOURNE",
    "lga": "Port Phillip",
    "distance_in_meters": 958.65
  },
  {
    "postcode": "3205",
    "suburb": "SOUTH MELBOURNE DC",
    "lga": "Port Phillip",
    "distance_in_meters": 958.65
  },
  {
    "postcode": "3000",
    "suburb": "MELBOURNE",
    "lga": "Melbourne",
    "distance_in_meters": 1410.5
  },
  {
    "postcode": "3004",
    "suburb": "MELBOURNE",
    "lga": "Melbourne",
    "distance_in_meters": 1645.48
  }
]
```