### PR TITLE
Allow deep-linking suburbs

### DIFF
--- a/src/web/package-lock.json
+++ b/src/web/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@mdi/font": "^7.4.47",
+        "slugify": "^1.6.6",
         "validator": "^13.15.15",
         "vite-plugin-vuetify": "^2.1.2",
         "vue": "^3.5.0",
@@ -1252,6 +1253,15 @@
         "@rollup/rollup-win32-ia32-msvc": "4.50.2",
         "@rollup/rollup-win32-x64-msvc": "4.50.2",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/slugify": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/source-map-js": {

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@mdi/font": "^7.4.47",
+    "slugify": "^1.6.6",
     "validator": "^13.15.15",
     "vite-plugin-vuetify": "^2.1.2",
     "vue": "^3.5.0",

--- a/src/web/src/TopSuburbs.vue
+++ b/src/web/src/TopSuburbs.vue
@@ -8,7 +8,6 @@
         </v-col>
       </v-row>
 
-      <!-- Controls Section -->
       <v-row class="mb-4">
         <v-col
           cols="12"
@@ -56,7 +55,6 @@
         </v-col>
       </v-row>
 
-      <!-- Error Alert -->
       <v-row v-if="error">
         <v-col cols="12">
           <v-alert type="error" density="compact">
@@ -65,7 +63,6 @@
         </v-col>
       </v-row>
 
-      <!-- Data Table -->
       <v-row>
         <v-col cols="12">
           <v-card elevation="1">
@@ -94,6 +91,16 @@
                   </v-chip>
                 </div>
               </template>
+              <template #item.actions="{ item }">
+                <v-btn
+                  color="primary"
+                  variant="outlined"
+                  size="small"
+                  @click="viewSuburbDetails(item)"
+                >
+                  View Details
+                </v-btn>
+              </template>
             </v-data-table>
           </v-card>
         </v-col>
@@ -105,7 +112,11 @@
 
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import slugify from 'slugify'
 import { safetyLabel, safetyColor } from './utils/safety'
+
+const router = useRouter()
 
 type Scope = 'postcode' | 'lga'
 type Order = 'asc' | 'desc'
@@ -130,6 +141,7 @@ const headers = computed(() => {
         { title: 'Suburb', key: 'suburb' },
         { title: 'LGA', key: 'lga' },
         { title: 'Safety Score', key: 'safety_score' },
+        { title: '', key: 'actions', sortable: false },
       ]
     : [
         { title: 'LGA', key: 'lga' },
@@ -173,9 +185,17 @@ async function fetchData() {
   }
 }
 
+const createSlug = (suburb: string, postcode: string): string => {
+  return slugify(`${suburb} ${postcode}`, { lower: true, strict: true });
+}
+
+const viewSuburbDetails = (item: any) => {
+  const slug = createSlug(item.suburb, item.postcode);
+  router.push({ name: 'suburb', params: { slug } });
+}
+
 watch([scope, order, limit], fetchData, { immediate: true })
 </script>
 
 <style scoped>
-/* Mobile-first responsive design handled by Vuetify grid system */
 </style>

--- a/src/web/src/components/ParkingCard.vue
+++ b/src/web/src/components/ParkingCard.vue
@@ -1,6 +1,9 @@
 <template>
   <v-card class="mb-3" elevation="1">
-    <v-card-item>
+    <v-card-item
+      class="clickable-header"
+      @click="navigateToSuburb"
+    >
       <template v-slot:prepend>
         <v-icon color="primary">mdi-map-marker</v-icon>
       </template>
@@ -14,7 +17,7 @@
           icon
           variant="plain"
           size="small"
-          @click="toggleFavourite"
+          @click.stop="toggleFavourite"
         >
           <v-icon
             :color="isFavourite ? 'yellow-darken-2' : 'grey-lighten-1'"
@@ -87,6 +90,10 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue';
+import { useRouter } from 'vue-router';
+import slugify from 'slugify';
+
+const router = useRouter();
 
 interface Facility {
   facility_id: number;
@@ -204,7 +211,16 @@ const getFacilityIcon = (facilityName: string) => {
   return icons[facilityName] || 'mdi-star';
 };
 
-//  This works surprisingly well, Google will fill in the blanks on your current location 
+const createSlug = (suburb: string, postcode: string): string => {
+  return slugify(`${suburb} ${postcode}`, { lower: true, strict: true });
+};
+
+const navigateToSuburb = () => {
+  const slug = createSlug(props.submission.suburb, props.submission.postcode);
+  router.push({ name: 'suburb', params: { slug } });
+};
+
+//  This works surprisingly well, Google will fill in the blanks on your current location
 const openDirections = () => {
   const fullAddress = `${props.submission.address}, ${props.submission.suburb}, ${props.submission.postcode}`;
   const encodedAddress = encodeURIComponent(fullAddress);
@@ -216,5 +232,14 @@ const openDirections = () => {
 <style scoped>
 .gap-1 {
   gap: 0.25rem;
+}
+
+.clickable-header {
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.clickable-header:hover {
+  background-color: rgba(var(--v-theme-primary), 0.05);
 }
 </style>

--- a/src/web/src/router/index.ts
+++ b/src/web/src/router/index.ts
@@ -7,6 +7,7 @@ import NotFound from '../NotFound.vue'
 
 const routes = [
   { path: '/', name: 'home', component: Homepage },
+  { path: '/suburb/:slug', name: 'suburb', component: Homepage, props: true },
   { path: '/top-suburbs', name: 'top-suburbs', component: TopSuburbs },
   { path: '/saved', name: 'saved', component: Saved },
   { path: '/contact', name: 'contact', component: Contact },


### PR DESCRIPTION
When navigating to a suburb the URL will add a slug, which can then be referenced and navigated to. This allows us to select the header of the parking location in the saved list to go to the suburb view, and the same for the top suburbs by clicking "view details"

<img width="2560" height="1250" alt="image" src="https://github.com/user-attachments/assets/76184e22-92ca-4eb9-a2d7-eb969aa01c71" />
