### PR TITLE
Use the empty-state component for parking suggestions

### DIFF
--- a/src/web/src/components/ParkingCard.vue
+++ b/src/web/src/components/ParkingCard.vue
@@ -12,6 +12,10 @@
         {{ submission.address }}
       </v-card-title>
 
+      <v-card-subtitle class="text-body-2">
+        {{ submission.postcode }}
+      </v-card-subtitle>
+
       <template v-slot:append>
         <v-btn
           icon

--- a/src/web/src/components/ParkingFeed.vue
+++ b/src/web/src/components/ParkingFeed.vue
@@ -29,9 +29,14 @@
             <v-progress-circular indeterminate size="32"></v-progress-circular>
           </v-card-text>
 
-          <v-card-text v-else-if="submissions.length === 0" class="text-center py-8">
-            <p class="text-grey text-body-1">No parking suggestions yet for this area</p>
-          </v-card-text>
+          <v-empty-state v-else-if="submissions.length === 0">
+            <template v-slot:media>
+              <v-icon size="64" color="grey-lighten-1">mdi-parking</v-icon>
+            </template>
+            <template v-slot:title>
+              <h3 class="text-grey">No parking suggestions yet</h3>
+            </template>
+          </v-empty-state>
 
           <v-card-text v-else class="pa-3">
             <ParkingCard


### PR DESCRIPTION
This is consistent with other places we use it (our 404 page and saved page)

<img width="2560" height="1250" alt="image" src="https://github.com/user-attachments/assets/8986918c-faeb-40c8-9c21-4312adcd5147" />
